### PR TITLE
ci: GitHub ActionsでCIワークフローを追加

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,18 @@
+name: Setup pnpm
+description: Setup pnpm
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup pnpm
+      uses: pnpm/action-setup@b9e1dbc72ff7358f971cc0b7c62c7a0d83f1068b
+
+    - name: Setup Node.js
+      uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f
+      with:
+        node-version-file: 'package.json'
+        cache: 'pnpm'
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: ci
+
+on: pull_request
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
+      - name: Run check
+        run: pnpm biome ci


### PR DESCRIPTION
## Summary
- PRに対して `biome ci` を実行するワークフローを追加
- pnpmセットアップ用の再利用可能なアクションを追加

## Test plan
- [ ] PRを作成するとCIが実行される
- [ ] biome ciが正常に完了する

🤖 Generated with [Claude Code](https://claude.com/claude-code)